### PR TITLE
ci: automate sources.json updates via GitHub Actions 

### DIFF
--- a/.github/workflows/update-sources.yml
+++ b/.github/workflows/update-sources.yml
@@ -1,0 +1,100 @@
+# Copyright 2024 RustFS Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Update Sources
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Daily at midnight
+  workflow_dispatch: # Manual trigger
+
+jobs:
+  update-sources:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Update sources.json
+        id: update_script
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          REPO="rustfs/rustfs"
+          LATEST_RELEASE=$(gh api repos/$REPO/releases/latest)
+          VERSION=$(echo "$LATEST_RELEASE" | jq -r '.tag_name')
+          CURRENT_VERSION=$(jq -r '.version' sources.json)
+
+          if [ "$VERSION" == "$CURRENT_VERSION" ]; then
+            echo "Already up to date ($VERSION)"
+            echo "updated=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Updating to $VERSION..."
+
+          # Temporary file for new sources
+          cat <<EOF > sources.json.new
+          {
+            "version": "$VERSION",
+            "downloadBase": "https://github.com/$REPO/releases/download",
+            "files": {
+              "x86_64-linux": { "name": "rustfs-linux-x86_64-musl-latest.zip" },
+              "aarch64-linux": { "name": "rustfs-linux-aarch64-musl-latest.zip" },
+              "x86_64-darwin": { "name": "rustfs-macos-x86_64-latest.zip" },
+              "aarch64-darwin": { "name": "rustfs-macos-aarch64-latest.zip" }
+            }
+          }
+          EOF
+
+          # Calculate SHA256 for each file
+          for system in "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"; do
+            FILE_NAME=$(jq -r ".files[\"$system\"].name" sources.json.new)
+            URL="https://github.com/$REPO/releases/download/$VERSION/$FILE_NAME"
+            echo "Fetching hash for $URL..."
+            HASH=$(nix-prefetch-url --type sha256 "$URL")
+            jq ".files[\"$system\"].sha256 = \"$HASH\"" sources.json.new > sources.json.tmp && mv sources.json.tmp sources.json.new
+          done
+
+          mv sources.json.new sources.json
+          echo "updated=true" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.update_script.outputs.updated == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update sources.json to ${{ steps.update_script.outputs.version }}"
+          committer: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          branch: "automation/update-sources-${{ steps.update_script.outputs.version }}"
+          delete-branch: true
+          title: "chore: update rustfs to ${{ steps.update_script.outputs.version }}"
+          body: |
+            ## Description
+            This is an automated PR to update the RustFS prebuilt binaries to version `${{ steps.update_script.outputs.version }}`.
+
+            ### Changes
+            - Updated `sources.json` with new download URLs and SHA256 hashes.
+            
+            Verified by GitHub Actions.
+          labels: |
+            dependencies
+            automated-pr


### PR DESCRIPTION
## Summary
This PR introduces a GitHub Actions workflow to automate the maintenance of `sources.json`. It ensures the flake always points to the latest upstream RustFS binaries without manual intervention.

## Key Features
- **Automated Tracking**: Checks for new releases from `rustfs/rustfs` daily.
- **Nix-Native Hashing**: Uses `nix-prefetch-url` to generate accurate SHA256 hashes for all supported platforms.
- **Safe Deployment**: Creates a dedicated branch and Pull Request for each update, adhering to branch protection rules.
- **Manual Trigger**: Includes `workflow_dispatch` for on-demand updates.

## Workflow Details
1. Fetches the latest tag from GitHub API.
2. Compares with the local version in `sources.json`.
3. If a new version exists, it downloads and hashes binaries for:
   - `x86_64-linux` / `aarch64-linux`
   - `x86_64-darwin` / `aarch64-darwin`
4. Submits a PR with the updated metadata.