### PR TITLE
fix: remove deprecated use of top-level `system` attribute

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
 
       # Overlays for extending nixpkgs
       overlays.default = final: prev: {
-        rustfs = self.packages.${prev.system}.default;
+        rustfs = self.packages.${prev.stdenv.hostPlatform.system}.default;
       };
 
       packages = forAllSystems (system:


### PR DESCRIPTION
Direct use of `pkgs.system` has been deprecated in favor of `pkgs.stdenv.hostPlatform.system`. Here, `prev` has the value of `pkgs`.