### PR TITLE
fix: refresh source hashes on asset drift

### DIFF
--- a/.github/workflows/update-sources.yml
+++ b/.github/workflows/update-sources.yml
@@ -45,24 +45,17 @@ jobs:
           REPO="rustfs/rustfs"
           LATEST_RELEASE=$(gh api "repos/$REPO/releases" --jq 'first')
           VERSION=$(echo "$LATEST_RELEASE" | jq -r '.tag_name')
-          CURRENT_VERSION=$(jq -r '.version' sources.json)
 
-          if [ "$VERSION" == "$CURRENT_VERSION" ]; then
-            echo "Already up to date ($VERSION)"
-            echo "updated=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Updating to $VERSION..."
+          echo "Checking sources for $VERSION..."
 
           cat <<EOF > sources.json.new
           {
             "version": "$VERSION",
             "downloadBase": "https://github.com/$REPO/releases/download",
             "files": {
-              "x86_64-linux": { "name": "rustfs-linux-x86_64-musl-latest.zip" },
-              "aarch64-linux": { "name": "rustfs-linux-aarch64-musl-latest.zip" },
-              "aarch64-darwin": { "name": "rustfs-macos-aarch64-latest.zip" }
+              "x86_64-linux": { "name": "rustfs-linux-x86_64-musl-v$VERSION.zip" },
+              "aarch64-linux": { "name": "rustfs-linux-aarch64-musl-v$VERSION.zip" },
+              "aarch64-darwin": { "name": "rustfs-macos-aarch64-v$VERSION.zip" }
             }
           }
           EOF
@@ -79,6 +72,13 @@ jobs:
             jq --arg sys "$system" --arg hash "$HASH" '.files[$sys].sha256 = $hash' sources.json.new > sources.json.tmp
             mv sources.json.tmp sources.json.new
           done
+
+          if cmp -s sources.json sources.json.new; then
+            echo "sources.json already matches $VERSION"
+            rm sources.json.new
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           mv sources.json.new sources.json
           echo "updated=true" >> "$GITHUB_OUTPUT"

--- a/sources.json
+++ b/sources.json
@@ -3,15 +3,15 @@
   "downloadBase": "https://github.com/rustfs/rustfs/releases/download",
   "files": {
     "x86_64-linux": {
-      "name": "rustfs-linux-x86_64-musl-latest.zip",
+      "name": "rustfs-linux-x86_64-musl-v1.0.0-beta.11-preview.1.zip",
       "sha256": "7f6104cab9914d31654e7bfc5fc6d59f1f622c2d91f92639b261c73ebdd448ed"
     },
     "aarch64-linux": {
-      "name": "rustfs-linux-aarch64-musl-latest.zip",
+      "name": "rustfs-linux-aarch64-musl-v1.0.0-beta.11-preview.1.zip",
       "sha256": "4d5920fe0599843cb76442c8be8c8216f9ed17cf23c13f8a6c29f5ab07ba2c4d"
     },
     "aarch64-darwin": {
-      "name": "rustfs-macos-aarch64-latest.zip",
+      "name": "rustfs-macos-aarch64-v1.0.0-beta.11-preview.1.zip",
       "sha256": "288f14180067a96012dd237f9a297c2ec35e2c70cac3ebe03137bdf5eee483b4"
     }
   }


### PR DESCRIPTION
## Description

Fix the automated source refresh flow so it can recover when RustFS release assets are re-uploaded under the same release tag.

## Root cause

The update workflow skipped work whenever the latest release tag matched `sources.json`. If an upstream fixed-output asset changed after the tag was already recorded, the scheduled workflow reported success without refreshing the stored hash.

## Changes

- Always regenerate `sources.json` for the latest RustFS release and compare the generated file with the checked-in file.
- Use versioned release asset names (`*-v${VERSION}.zip`) instead of `*-latest.zip` aliases.
- Keep the existing Nix prefetch path so hashes are verified against the same downloads Nix will fetch.

## Validation

- `jq empty sources.json`
- Ruby YAML parse for both workflow files
- `actionlint`
- `git diff --check`
- Confirmed the versioned `1.0.0-beta.11-preview.1` release assets exist and their GitHub `digest` values match `sources.json`

Local `nix` is not installed in this environment, so the full `nix build` validation is left to GitHub Actions.