### PR TITLE
fix: patch Darwin liblzma linkage

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
         let
           pkgs = import nixpkgs { inherit system; };
           srcInfo = sources.files.${system} or (throw "Unsupported system: ${system}");
+          isDarwin = pkgs.stdenvNoCC.hostPlatform.isDarwin;
         in
         {
           default = pkgs.stdenvNoCC.mkDerivation {
@@ -56,9 +57,11 @@
               sha256 = srcInfo.sha256;
             };
 
-            # Build Tools:
-            # - unzip: Required for extracting the source archive.
-            nativeBuildInputs = [ pkgs.unzip ];
+            nativeBuildInputs =
+              [ pkgs.unzip ]
+              ++ pkgs.lib.optionals isDarwin [
+                pkgs.darwin.cctools
+              ];
 
             # The archive contains the binary at the root, so we set sourceRoot to current dir
             sourceRoot = ".";
@@ -69,6 +72,13 @@
               mkdir -p $out/bin
               install -m755 rustfs $out/bin/rustfs
 
+              ${pkgs.lib.optionalString isDarwin ''
+                mkdir -p $out/lib
+                cp ${pkgs.xz.out}/lib/liblzma.5.dylib $out/lib/
+                install_name_tool -change /opt/homebrew/opt/xz/lib/liblzma.5.dylib \
+                  @executable_path/../lib/liblzma.5.dylib \
+                  $out/bin/rustfs
+              ''}
 
               runHook postInstall
             '';


### PR DESCRIPTION
## Summary

Fix the aarch64-darwin package so the prebuilt RustFS binary no longer depends on Homebrew's absolute `liblzma` path at runtime.

## Root Cause

The upstream macOS aarch64 release binary currently contains this Mach-O load command:

```text
/opt/homebrew/opt/xz/lib/liblzma.5.dylib
```

The flake installs the downloaded binary unchanged, so `packages.aarch64-darwin.default` can fail in a clean Nix environment where Homebrew's xz is not installed at that exact path.

## Changes

- Add Darwin-only `install_name_tool` support during the package install phase.
- Copy Nixpkgs' `xz` `liblzma.5.dylib` into `$out/lib`.
- Rewrite the RustFS binary to load `@executable_path/../lib/liblzma.5.dylib`.
- Leave Linux package behavior unchanged.

## Validation

- `git diff --check`
- `jq empty sources.json`
- `actionlint`
- Ruby YAML parse for `.github/workflows/*.yml`
- PR CI passed:
  - `Lint and Evaluate`
  - `Build Linux package`
- Local Mach-O patch simulation against the current `1.0.0-beta.12` macOS aarch64 asset:
  - source zip SHA256 matched `sources.json`
  - `otool -L` changed from `/opt/homebrew/opt/xz/lib/liblzma.5.dylib` to `@executable_path/../lib/liblzma.5.dylib`
  - `codesign --verify --verbose` remained valid
  - patched `$out/bin/rustfs --help` ran successfully

Local `nix` is not installed in this checkout environment, and the existing repository CI does not include a macOS package build job. A full `nix build .#packages.aarch64-darwin.default` still needs to be run in a Nix-enabled macOS environment.

Fixes #51.
